### PR TITLE
eliminate warnings in XCode 8.3

### DIFF
--- a/Pod/Classes/I3DragDataSource.h
+++ b/Pod/Classes/I3DragDataSource.h
@@ -126,7 +126,7 @@
  
  @name Coordination
  @param from            The index from the original collection that the item is from
- @param to              The index path on the target collection that we're dropping on
+ @param at              The point on the target collection where we're dropping
  @param fromCollection  The original collection that we're dragging from.
  @param toCollection      The target collection that we're dragging to.
  @return BOOL

--- a/Pod/Classes/I3GestureCoordinator.h
+++ b/Pod/Classes/I3GestureCoordinator.h
@@ -160,7 +160,7 @@
  view.
  
  @param viewController      This controller's main view is used as the arena's superview
- @param collection          An array of UIView<I3Collection> objects
+ @param collections         An array of UIView<I3Collection> objects
  @param recognizer          The recognizer to listen to.
  
  */
@@ -173,7 +173,7 @@
  with a nil recognizer.
  
  @param viewController      This controller's main view is used as the arena's superview
- @param collection          An array of UIView<I3Collection> objects
+ @param collections         An array of UIView<I3Collection> objects
  
  */
 +(instancetype) basicGestureCoordinatorFromViewController:(UIViewController *)viewController withCollections:(NSArray *)collections;


### PR DESCRIPTION
Some small improvements to the documentation make BetweenKit compile without warning once again in XCode 8.3.